### PR TITLE
Implement direct solve of symmetric linear equations for eeq_chrgeq

### DIFF
--- a/include/dftd_cblas.h
+++ b/include/dftd_cblas.h
@@ -272,16 +272,7 @@ inline int BLAS_SolveSymmetric(
 
     // Solve for all RHS columns
     info = LAPACKE_dsytrs(
-        LAPACK_ROW_MAJOR,
-        'L',
-        m,
-        nrhs,
-        A.p,
-        m,
-        ipiv,
-        B.p,
-        nrhs
-    );
+        LAPACK_ROW_MAJOR, 'L', m, nrhs, A.p, m, ipiv, B.p, nrhs);
     delete[] ipiv;
 
     if (info != 0) {

--- a/include/dftd_cblas.h
+++ b/include/dftd_cblas.h
@@ -236,4 +236,59 @@ inline int BLAS_InvertMatrix(TMatrix<double> &a) {
   return EXIT_SUCCESS;
 };
 
+/**
+ * @brief Solve a symmetric linear system A * X = B for X.
+ *
+ * This routine factorizes a symmetric matrix A using Bunch-Kaufman factorization
+ * and solves for the right-hand side vector B. The matrix A is overwritten
+ * by its factorization. The solution overwrites B.
+ *
+ * @param A Symmetric matrix of size (m x m). Overwritten by the factorization.
+ * @param B Right-hand side vector of size m. Overwritten by the solution.
+ * @return int Returns EXIT_SUCCESS (0) on success, EXIT_FAILURE (1) on error.
+ */
+inline int BLAS_SolveSymmetric(
+    TMatrix<double> &A,   // symmetric matrix
+    TVector<double> &B    // RHS vector (becomes solution)
+) {
+    const lapack_int m    = A.rows;
+    const lapack_int nrhs = 1;
+
+    if (A.cols != m || B.N != m) {
+        fprintf(stderr, "BLAS_SolveSymmetric error: dimension mismatch\n");
+        return EXIT_FAILURE;
+    }
+
+    lapack_int info;
+    lapack_int *ipiv = new lapack_int[A.rows];
+
+    // Factorization
+    info = LAPACKE_dsytrf( LAPACK_ROW_MAJOR, 'L', m, A.p, m, ipiv );
+    if (info != 0) {
+        delete[] ipiv;
+        fprintf(stderr, "dsytrf failed: info=%d\n", (int)info);
+        return EXIT_FAILURE;
+    }
+
+    // Solve for all RHS columns
+    info = LAPACKE_dsytrs(
+        LAPACK_ROW_MAJOR,
+        'L',
+        m,
+        nrhs,
+        A.p,
+        m,
+        ipiv,
+        B.p,
+        nrhs
+    );
+    delete[] ipiv;
+
+    if (info != 0) {
+        fprintf(stderr, "dsytrs failed: info=%d\n", (int)info);
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}
+
 } // namespace dftd4

--- a/src/dftd_eeq.cpp
+++ b/src/dftd_eeq.cpp
@@ -145,7 +145,6 @@ int ChargeModel::eeq_chrgeq(
     info = BLAS_SolveSymmetric(Amat, rhs);
     if (info != EXIT_SUCCESS) return info;
 
-
     // Extract solution
     for (int i = 0; i < m; i++) {
         vrhs(i) = rhs(i);

--- a/src/dftd_eeq.cpp
+++ b/src/dftd_eeq.cpp
@@ -121,17 +121,36 @@ int ChargeModel::eeq_chrgeq(
   TVector<double> vrhs;
   vrhs.NewVec(m);
 
+  // Need inverse for dqdr
   TMatrix<double> Ainv;
-  Ainv.NewMat(m, m);
-  Ainv.CopyMat(Amat);
+  if (lgrad) {
+    Ainv.NewMat(m, m);
+    Ainv.CopyMat(Amat);
 
-  // solve: A Q = X (Eq.4) -> Q = Ainv X
-  info = BLAS_InvertMatrix(Ainv);
-  if (info != EXIT_SUCCESS) return info;
+    // solve: A Q = X
+    info = BLAS_InvertMatrix(Ainv);
+    if (info != EXIT_SUCCESS) return info;
 
-  // no return in ORCA
-  BLAS_Add_Mat_x_Vec(vrhs, Ainv, xvec, false, 1.0);
-  // if (info != EXIT_SUCCESS) return info;
+    // no return in ORCA
+    BLAS_Add_Mat_x_Vec(vrhs, Ainv, xvec, false, 1.0);
+    // if (info != EXIT_SUCCESS) return info;
+  } else {
+    // direct solve: A Q = X
+    TVector<double> rhs;
+    rhs.NewVec(m);
+    rhs.CopyVec(xvec);
+
+    // Now solve (A * q = x) for symmetric Amat
+    // Note that only lower triangle of Amat is updated
+    info = BLAS_SolveSymmetric(Amat, rhs);
+    if (info != EXIT_SUCCESS) return info;
+
+
+    // Extract solution
+    for (int i = 0; i < m; i++) {
+        vrhs(i) = rhs(i);
+    }
+  }
 
   // remove charge constraint (make vector smaller by one) and total charge
   qtotal = 0.0;
@@ -212,10 +231,10 @@ int ChargeModel::eeq_chrgeq(
     // if (info != EXIT_SUCCESS) return info;
 
     dAmat.DelMat();
+    Ainv.DelMat();
   }
 
   // free all memory
-  Ainv.DelMat();
   Amat.DelMat();
   xvec.DelVec();
 

--- a/test/test_multi.cpp
+++ b/test/test_multi.cpp
@@ -71,7 +71,7 @@ int test_multi_functions(){
   TVector<double> q;
   TMatrix<double> dqdr;
   q.NewVector(mb16_43_01_n);
-  dqdr.NewMatrix(mb16_43_01_n, mb16_43_01_n);
+  dqdr.NewMatrix(3*mb16_43_01_n, mb16_43_01_n);
 
   eeqbc_model.get_cn(mol, realIdx, dist, cn, dcndr, false);
   info = eeqbc_model.eeq_chrgeq(mol, realIdx, dist, cn, dcndr, mb16_43_01_charge, q, dqdr, false, false);


### PR DESCRIPTION
Until now, we have always formed the inverse of the Coulomb matrix, which is faster if we need to calculate dqdr. However, if this gradient is not needed, we want to solve the set of linear equations directly as implemented in this PR.