### PR TITLE
Fix gradient for periodic ATM contribution

### DIFF
--- a/src/damping/dftd_atm.cpp
+++ b/src/damping/dftd_atm.cpp
@@ -300,15 +300,15 @@ int get_atm_dispersion_derivs(
         dgyjk = c9ijk * (-dang * fdmp + ang * dfdmp) / r2jk * yjk;
         dgzjk = c9ijk * (-dang * fdmp + ang * dfdmp) / r2jk * zjk;
 
-        gradient(3 * ii + 0) += -dgxij - dgxik;
-        gradient(3 * ii + 1) += -dgyij - dgyik;
-        gradient(3 * ii + 2) += -dgzij - dgzik;
-        gradient(3 * jj + 0) += dgxij - dgxjk;
-        gradient(3 * jj + 1) += dgyij - dgyjk;
-        gradient(3 * jj + 2) += dgzij - dgzjk;
-        gradient(3 * kk + 0) += dgxik + dgxjk;
-        gradient(3 * kk + 1) += dgyik + dgyjk;
-        gradient(3 * kk + 2) += dgzik + dgzjk;
+        gradient(3 * ii + 0) += -(dgxij + dgxik) * triple;
+        gradient(3 * ii + 1) += -(dgyij + dgyik) * triple;
+        gradient(3 * ii + 2) += -(dgzij + dgzik) * triple;
+        gradient(3 * jj + 0) += (dgxij - dgxjk) * triple;
+        gradient(3 * jj + 1) += (dgyij - dgyjk) * triple;
+        gradient(3 * jj + 2) += (dgzij - dgzjk) * triple;
+        gradient(3 * kk + 0) += (dgxik + dgxjk) * triple;
+        gradient(3 * kk + 1) += (dgyik + dgyjk) * triple;
+        gradient(3 * kk + 2) += (dgzik + dgzjk) * triple;
 
         dEdcn(ii) -= e * 0.5 * (dc6dcn(ii, jj) / c6ij + dc6dcn(ii, kk) / c6ik);
         dEdcn(jj) -= e * 0.5 * (dc6dcn(jj, ii) / c6ij + dc6dcn(jj, kk) / c6jk);


### PR DESCRIPTION
See: https://github.com/dftd4/dftd4/pull/359.

Since cpp-d4 does not implement PBC, this bug is actually never triggered.